### PR TITLE
Use Medium quality for embedded raster rendering

### DIFF
--- a/src/backend_skia_bindings/image.rs
+++ b/src/backend_skia_bindings/image.rs
@@ -32,7 +32,7 @@ pub fn draw_raster(
     };
 
 
-    let mut filter = skia::FilterQuality::Low;
+    let mut filter = skia::FilterQuality::Medium;
     if rendering_mode == usvg::ImageRendering::OptimizeSpeed {
         filter = skia::FilterQuality::None;
     }


### PR DESCRIPTION
This fixes https://canvadev.atlassian.net/browse/CA-21079. Unfortunately, I don't have a link to Chromium code to prove that Medium is the correct quality to use, but it seems to produce the same result as High, even for upscaled images.