### PR TITLE
[CA-21153] Fix raster alignment

### DIFF
--- a/src/backend_skia_bindings/image.rs
+++ b/src/backend_skia_bindings/image.rs
@@ -59,7 +59,7 @@ pub fn draw_raster(
     );
     canvas.draw_image_rect(
         &image.image_snapshot(),
-        Some((&new_rect, SkCanvas_SrcRectConstraint::Strict)),
+        Some((&src_rect, SkCanvas_SrcRectConstraint::Strict)),
         &dest_rect,
         &paint,
     );

--- a/src/backend_skia_bindings/image.rs
+++ b/src/backend_skia_bindings/image.rs
@@ -59,7 +59,7 @@ pub fn draw_raster(
     );
     canvas.draw_image_rect(
         &image.image_snapshot(),
-        Some((&src_rect, SkCanvas_SrcRectConstraint::Strict)),
+        Some((&src_rect, SkCanvas_SrcRectConstraint::Fast)),
         &dest_rect,
         &paint,
     );

--- a/src/backend_skia_bindings/image.rs
+++ b/src/backend_skia_bindings/image.rs
@@ -8,7 +8,7 @@ use usvg::try_opt;
 use crate::prelude::*;
 use crate::backend_utils::{self, ConvTransform, Image};
 use crate::backend_skia_bindings::skia_bindings::ToData;
-use skia_bindings::SkCanvas_SrcRectConstraint;
+use skia_safe::canvas::SrcRectConstraint;
 
 pub fn draw_raster(
     format: usvg::ImageFormat,
@@ -59,7 +59,7 @@ pub fn draw_raster(
     );
     canvas.draw_image_rect(
         &image.image_snapshot(),
-        Some((&src_rect, SkCanvas_SrcRectConstraint::Fast)),
+        Some((&src_rect, SrcRectConstraint::Fast)),
         &dest_rect,
         &paint,
     );

--- a/src/backend_skia_bindings/image.rs
+++ b/src/backend_skia_bindings/image.rs
@@ -8,6 +8,7 @@ use usvg::try_opt;
 use crate::prelude::*;
 use crate::backend_utils::{self, ConvTransform, Image};
 use crate::backend_skia_bindings::skia_bindings::ToData;
+use skia_bindings::SkCanvas_SrcRectConstraint;
 
 pub fn draw_raster(
     format: usvg::ImageFormat,
@@ -49,8 +50,19 @@ pub fn draw_raster(
     paint.set_filter_quality(filter);
     let r = backend_utils::image::image_rect(&view_box, img.size);
 
-    let left_top = skia::Point::new(r.x() as f32, r.y() as f32);
-    canvas.draw_image(&image.image_snapshot(), left_top, Some(&paint));
+    let src_rect = skia::Rect::new(0.0, 0.0, image.width() as f32, image.height() as f32);
+    let dest_rect = skia::Rect::new(
+        r.left() as f32,
+        r.top() as f32,
+        r.right() as f32,
+        r.bottom() as f32,
+    );
+    canvas.draw_image_rect(
+        &image.image_snapshot(),
+        Some((&new_rect, SkCanvas_SrcRectConstraint::Strict)),
+        &dest_rect,
+        &paint,
+    );
 
     // Revert.
     canvas.restore();


### PR DESCRIPTION
Fixes alignment with embedded rasters where the raster is scaled above/below its native resolution. This also supports viewboxes within the rasters too.

https://canvadev.atlassian.net/browse/CA-21153